### PR TITLE
docs: add DevEx to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dj8yfo @akorchyn @PolyProgrammist
+* @near/devex


### PR DESCRIPTION
This PR updates the CODEOWNERS file to reflect the maintenance structure moving forward: near/devex#7
