### PR TITLE
fix(ci): make staging account creation idempotent

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,14 +22,13 @@ jobs:
       - name: Install near CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.20.0/near-cli-rs-installer.sh | sh
       - name: Create staging account
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
         run: |
           near account create-account fund-myself "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" '10 NEAR' \
             use-manually-provided-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
             sign-as "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
             network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
             sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            send
+            send || true
 
       - name: Install cargo-near CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.15.0/cargo-near-installer.sh | sh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,12 +23,17 @@ jobs:
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.20.0/near-cli-rs-installer.sh | sh
       - name: Create staging account
         run: |
-          near account create-account fund-myself "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" '10 NEAR' \
-            use-manually-provided-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-            sign-as "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
-            network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            send || true
+          if near account view-account-summary "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
+            network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" now > /dev/null 2>&1; then
+            echo "Account ${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }} already exists, skipping creation"
+          else
+            near account create-account fund-myself "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" '10 NEAR' \
+              use-manually-provided-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
+              sign-as "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
+              network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
+              sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+              send
+          fi
 
       - name: Install cargo-near CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.15.0/cargo-near-installer.sh | sh

--- a/.github/workflows/undeploy-staging.yml
+++ b/.github/workflows/undeploy-staging.yml
@@ -16,8 +16,13 @@ jobs:
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.20.0/near-cli-rs-installer.sh | sh
       - name: Remove staging account
         run: |
-          near account delete-account "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
-            beneficiary "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
-            network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            send
+          if near account view-account-summary "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
+            network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" now > /dev/null 2>&1; then
+            near account delete-account "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
+              beneficiary "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
+              network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
+              sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+              send
+          else
+            echo "Account ${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }} does not exist, skipping cleanup"
+          fi


### PR DESCRIPTION
## Summary

- Make the staging subaccount creation step in the deploy workflow idempotent so it doesn't fail due to race conditions

## Problem

The "Create staging account" step only ran on `opened`/`reopened` PR events. If tests failed on the initial `opened` event, the account was never created. Subsequent pushes trigger `synchronize` events which skip account creation but still attempt deployment — causing the deploy to fail with "access key has never been observed on the node".

This happened on PR #25 and will recur for any PR where tests fail on the initial open.

## Fix

Removed the event-action guard on account creation and made it idempotent — the step now runs on every workflow invocation but gracefully handles the case where the account already exists (`|| true`). This ensures the staging account is always available for deployment regardless of prior CI run outcomes.