### PR TITLE
ci: skip staging deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,7 @@ jobs:
 
   deploy-staging:
     name: Deploy to staging subaccount
+    if: github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     needs: [test]


### PR DESCRIPTION
## Summary
- Dependabot PRs can't read repo Actions secrets (Dependabot has a separate secret store), so `secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY` is empty and the deploy step fails: `invalid value '' for '[SIGNER_PRIVATE_KEY]': invalid key length`.
- Add `if: github.actor != 'dependabot[bot]'` to the `deploy-staging` job so Dependabot PRs skip the deploy. The reusable `test` job still runs and covers the build.

## Test plan
- [ ] Merge and confirm the next Dependabot PR shows `Deploy to staging subaccount` as skipped while `test` runs green.
- [ ] Open a non-Dependabot PR and confirm the deploy job still runs and deploys to a `gh-<num>.<staging>` subaccount.